### PR TITLE
Removes magic number without changing functionality

### DIFF
--- a/Sources/ParallaxScrollView/ParallaxScrollView.swift
+++ b/Sources/ParallaxScrollView/ParallaxScrollView.swift
@@ -47,14 +47,11 @@ public struct ParallaxScrollView<
             headerBackground()
 
             ScrollView {
-                offsetReader
                 VStack(spacing: 0) {
+                    offsetReader
                     header()
                     content
                 }
-                // `offsetReader`, despite having zero height,
-                // pushes down the scrolling content by 8pt.
-                .offset(y: -8)
             }
             .coordinateSpace(name: Namespace.parallaxScrollView)
             .onPreferenceChange(ScrollOffsetPreferenceKey.self) { offset = $0 }


### PR DESCRIPTION
@mtzaquia I moved the `offsetReader` inside of the VStack and do not see any difference in how the scrollview behaves.

But it does remove the magic number reliance, is there anything I'm missing?