### PR TITLE
Move header to background

### DIFF
--- a/Sources/ParallaxScrollView/ParallaxScrollView.swift
+++ b/Sources/ParallaxScrollView/ParallaxScrollView.swift
@@ -47,14 +47,11 @@ public struct ParallaxScrollView<
             headerBackground()
 
             ScrollView {
-                offsetReader
                 VStack(spacing: 0) {
+                    offsetReader
                     header()
                     content
                 }
-                // `offsetReader`, despite having zero height,
-                // pushes down the scrolling content by 8pt.
-                .offset(y: -8)
             }
             .coordinateSpace(name: Namespace.parallaxScrollView)
             .onPreferenceChange(ScrollOffsetPreferenceKey.self) { offset = $0 }

--- a/Sources/ParallaxScrollView/ParallaxScrollView.swift
+++ b/Sources/ParallaxScrollView/ParallaxScrollView.swift
@@ -43,19 +43,16 @@ public struct ParallaxScrollView<
     @State var minimumHeight: CGFloat = .zero
 
     public var body: some View {
-        ZStack(alignment: .top) {
-            headerBackground()
-
-            ScrollView {
-                VStack(spacing: 0) {
-                    offsetReader
-                    header()
-                    content
-                }
+        ScrollView {
+            VStack(spacing: 0) {
+                offsetReader
+                header()
+                content
             }
-            .coordinateSpace(name: Namespace.parallaxScrollView)
-            .onPreferenceChange(ScrollOffsetPreferenceKey.self) { offset = $0 }
         }
+        .coordinateSpace(name: Namespace.parallaxScrollView)
+        .onPreferenceChange(ScrollOffsetPreferenceKey.self) { offset = $0 }
+        .background(alignment: .top) { headerBackground() }
     }
 
     /// Creates a new ``ParallaxScrollView``.


### PR DESCRIPTION
@mtzaquia you can use a background to position the `background` and avoid any ZStack layout shenanigans that could arise.